### PR TITLE
Emergency fix for coveralls ci:tests issue

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,10 @@
 require 'coveralls'
 Coveralls.wear_merged!('rails')
-require 'rspec/rails'
-require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
+require 'rspec/rails'
+require 'spec_helper'
+
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
 begin


### PR DESCRIPTION
The bundle exec rake ci:tests command doesn't work. 

Fixed it by moving up:
```ENV['RAILS_ENV'] ||= 'test'
require File.expand_path('../../config/environment', __FILE__)```

before

require 'rspec/rails'
require 'spec_helper'```

Error:

NameError:
  uninitialized constant ActionView::Template::Handlers::ERB::ENCODING_FLAG