### PR TITLE
Visitor can change language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+	before_action :set_locale
+
+	def set_locale
+		I18n.locale = params[:locale] || I18n.default_locale
+	end
 end

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,9 +1,9 @@
-=link_to_unless_current "English", locale: "en"
-=link_to_unless_current "Svenska", locale: "sv"
+= link_to_unless_current "English", locale: "en"
+= link_to_unless_current "Svenska", locale: "sv"
 %h1 The Hub News
 .articles
 	- @articles.each do |article|
 		.article_box{class: "w-1/3", id: "#{dom_id(article)}"}
-			=link_to article.title, article_path(article)
+			= link_to article.title, article_path(article)
 			%p= truncate(article.content, length: 100, separator: ' ', ommision: "... (Read More)")
 =link_to t('signup'), new_user_registration_path

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,7 +1,9 @@
+=link_to_unless_current "English", locale: "en"
+=link_to_unless_current "Svenska", locale: "sv"
 %h1 The Hub News
 .articles
 	- @articles.each do |article|
 		.article_box{class: "w-1/3", id: "#{dom_id(article)}"}
 			=link_to article.title, article_path(article)
 			%p= truncate(article.content, length: 100, separator: ' ', ommision: "... (Read More)")
-=link_to 'Become a subscriber', new_user_registration_path
+=link_to t('signup'), new_user_registration_path

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -6,4 +6,4 @@
 		.article_box{class: "w-1/3", id: "#{dom_id(article)}"}
 			= link_to article.title, article_path(article)
 			%p= truncate(article.content, length: 100, separator: ' ', ommision: "... (Read More)")
-=link_to t('signup'), new_user_registration_path
+= link_to t('signup'), new_user_registration_path

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,3 @@
-
 .form_container
   .form_wrapper
     %h2.text-center Become a Subscriber
@@ -22,4 +21,3 @@
           = f.password_field :password_confirmation, autocomplete: "new-password",class: "input_field"
         .flex.items-center.justify-between
           = f.submit "Sign up", class: "button"
- 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,5 @@
 require_relative 'boot'
-
 require "rails"
-# Pick the frameworks you want:
 require "active_model/railtie"
 require "active_job/railtie"
 require "active_record/railtie"
@@ -11,12 +9,13 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
+
 Bundler.require(*Rails.groups)
 
 module FarazalleTheHutNewsroomJan2019
   class Application < Rails::Application
     config.load_defaults 5.2
-    
+
     config.generators do |generate|
       generate.helper false
       generate.assets false
@@ -25,6 +24,8 @@ module FarazalleTheHutNewsroomJan2019
       generate.routing_specs false
       generate.controller_specs false
       generate.system_tests false
-    end
+		end
+		config.i18n.available_locales = [:sv, :en]
+		config.i18n.default_locale = :en
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,17 +1,2 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
 en:
   signup: Become a Subscriber

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,21 +13,5 @@
 # To use a different locale, set it with `I18n.locale`:
 #
 #     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  signup: Become a Subscriber

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,2 +1,2 @@
 en:
-  signup: Become a Subscriber
+  signup: Become a subscriber

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,0 +1,2 @@
+sv:
+  signup: Köp en prenumeration

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 2019_03_13_213311) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "access"
     t.string "image"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_03_13_213311) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "access"
     t.string "image"
   end
 

--- a/features/visitor_can_change_language.feature
+++ b/features/visitor_can_change_language.feature
@@ -8,7 +8,7 @@ Feature: Visitor can change language
 
 	Scenario: View list of articles on the landing page [English]
 			And I click on "English"
-			Then I should see "Become a Subscriber"
+			Then I should see "Become a subscriber"
 
 	Scenario: View list of articles on the landing page [Swedish]
 			And I click on "Svenska"

--- a/features/visitor_can_change_language.feature
+++ b/features/visitor_can_change_language.feature
@@ -1,15 +1,15 @@
 Feature: Visitor can change language
   As a visitor,
-	in order to read the articles in my native language,
+	In order to read the articles in my native language,
 	I would like to have the option to change the language to Swedish
 
 	Background:
-			Given I visit the "landing" page
+		Given I visit the "landing" page
 
 	Scenario: View list of articles on the landing page [English]
-			And I click on "English"
-			Then I should see "Become a subscriber"
+		When I click on "English"
+		Then I should see "Become a subscriber"
 
 	Scenario: View list of articles on the landing page [Swedish]
-			And I click on "Svenska"
-			Then I should see "Köp en prenumeration"
+		When I click on "Svenska"
+		Then I should see "Köp en prenumeration"

--- a/features/visitor_can_change_language.feature
+++ b/features/visitor_can_change_language.feature
@@ -1,0 +1,15 @@
+Feature: Visitor can change language
+  As a visitor,
+	in order to read the articles in my native language,
+	I would like to have the option to change the language to Swedish
+
+	Background:
+			Given I visit the "landing" page
+
+	Scenario: View list of articles on the landing page [English]
+			And I click on "English"
+			Then I should see "Become a Subscriber"
+
+	Scenario: View list of articles on the landing page [Swedish]
+			And I click on "Svenska"
+			Then I should see "Köp en prenumeration"


### PR DESCRIPTION
#### PT Story: [Pivotal Tracker](https://www.pivotaltracker.com/story/show/164626609)
#### Description
_As a visitor,
in order to read the articles in my native language,
I would like to have the option to change the language to Swedish_  

Changes proposed in this pull request:

* Add links for English and Swedish languages
* Set English as default language
#### What I have learned working on this feature:
How to implement different languages on a site.

#### Screenshots:
![image](https://user-images.githubusercontent.com/36330727/54367151-315e7200-4672-11e9-9118-d6839be039db.png)
![image](https://user-images.githubusercontent.com/36330727/54367224-5521b800-4672-11e9-8533-89a050dc211d.png)
