### PR TITLE
Visitor can see categorized articles

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,6 @@
 class ArticlesController < ApplicationController
 	def index
+		@categories = Category.all
 		@articles = Article.all
 	end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,6 @@
 class Article < ApplicationRecord
     validates :title, presence: true, length: { minimum: 5}
-    validates :content, presence: true, length: { minimum: 10}
+		validates :content, presence: true, length: { minimum: 10}
+		validates :category, presence: true
+		belongs_to :category
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,14 @@
+class Category < ApplicationRecord
+	has_many :articles
+	valid_categories = [
+		'sports',
+		'entertainment',
+		'local',
+		'global',
+		'tech',
+		'politics'
+	]
+	validates_inclusion_of :name, :in => valid_categories
+	validates :name, presence: true
+	validates_uniqueness_of :name
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -8,7 +8,7 @@ class Category < ApplicationRecord
 		'tech',
 		'politics'
 	]
-	validates_inclusion_of :name, :in => valid_categories
+	validates_inclusion_of :name, in: valid_categories
 	validates :name, presence: true
 	validates_uniqueness_of :name
 end

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,13 +1,16 @@
 = link_to_unless_current "English", locale: "en"
 = link_to_unless_current "Svenska", locale: "sv"
-= link_to 'Become a subscriber', new_user_registration_path
+= link_to t("signup"), new_user_registration_path
 %h1 The Hub News
 %ul.flex.justify-center
 	-@categories.each do |category|
 		%li.list-reset.p-4.text-lg= link_to category.name.capitalize, '#'
 
 .articles
-	- @articles.each do |article|
-		.article_box{class: "w-1/3", id: "#{dom_id(article)}"}
-			= link_to article.title, article_path(article)
-			%p= truncate(article.content, length: 100, separator: ' ', ommision: "... (Read More)")
+- @categories.each do |category|
+	%div{id: dom_id(category)}
+		%p= category.name
+		-category.articles.each do |article|
+			.article_box{class: "w-1/3", id: "#{dom_id(article)}"}
+				= link_to article.title, article_path(article)
+				%p= truncate(article.content, length: 100, separator: ' ', ommision: "... (Read More)")

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -2,14 +2,11 @@
 = link_to_unless_current "Svenska", locale: "sv"
 = link_to t("signup"), new_user_registration_path
 %h1 The Hub News
-%ul.flex.justify-center
-	-@categories.each do |category|
-		%li.list-reset.p-4.text-lg= link_to category.name.capitalize, '#'
 
 .articles
 - @categories.each do |category|
 	%div{id: dom_id(category)}
-		%p= category.name
+		%p= category.name.capitalize
 		-category.articles.each do |article|
 			.article_box{class: "w-1/3", id: "#{dom_id(article)}"}
 				= link_to article.title, article_path(article)

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -1,9 +1,13 @@
 = link_to_unless_current "English", locale: "en"
 = link_to_unless_current "Svenska", locale: "sv"
+= link_to 'Become a subscriber', new_user_registration_path
 %h1 The Hub News
+%ul.flex.justify-center
+	-@categories.each do |category|
+		%li.list-reset.p-4.text-lg= link_to category.name.capitalize, '#'
+
 .articles
 	- @articles.each do |article|
 		.article_box{class: "w-1/3", id: "#{dom_id(article)}"}
 			= link_to article.title, article_path(article)
 			%p= truncate(article.content, length: 100, separator: ' ', ommision: "... (Read More)")
-= link_to t('signup'), new_user_registration_path

--- a/db/migrate/20190314141417_create_categories.rb
+++ b/db/migrate/20190314141417_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190314141811_add_category_ref_to_article.rb
+++ b/db/migrate/20190314141811_add_category_ref_to_article.rb
@@ -1,0 +1,5 @@
+class AddCategoryRefToArticle < ActiveRecord::Migration[5.2]
+	def change
+		add_reference :articles, :category, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_13_213311) do
+ActiveRecord::Schema.define(version: 2019_03_14_141811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,14 @@ ActiveRecord::Schema.define(version: 2019_03_13_213311) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image"
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_articles_on_category_id"
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -35,4 +43,5 @@ ActiveRecord::Schema.define(version: 2019_03_13_213311) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "articles", "categories"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_14_141811) do
+ActiveRecord::Schema.define(version: 2019_03_14_193240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_03_14_141811) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image"
+    t.string "status"
     t.bigint "category_id"
     t.index ["category_id"], name: "index_articles_on_category_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,14 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-article1 = Article.create(title: "The Hub News is the site of the moment", content: "Great articles! This site's popularity is raising so quick!", image:"https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg")
-article2 = Article.create(title: "Spring hasn't arrived in Sweden yet", content: "Ice can be still spotted on the street, watch out!", image:"https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg")
-article3 = Article.create(title: "Eating cinnamon buns increases life expectancy", content: "Researchers are running clinical studies to see the benefits of cinnamon buns consumption. Some state that it might be correlated with an increase in life expectancy, is that really true?", image:"https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg")
+
+sports = Category.create(name: "sports")
+tech =	Category.create(name: "tech")
+local = Category.create(name: "local")
+global = Category.create(name: "global")
+entertainment = Category.create(name: "entertainment")
+politics = Category.create(name: "politics")
+
+article1 = Article.create(title: "The Hub News is the site of the moment", content: "Great articles! This site's popularity is raising so quick!", image:"https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg", category_id: 1)
+article2 = Article.create(title: "Spring hasn't arrived in Sweden yet", content: "Ice can be still spotted on the street, watch out!", image:"https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg", category_id: 2)
+article3 = Article.create(title: "Eating cinnamon buns increases life expectancy", content: "Researchers are running clinical studies to see the benefits of cinnamon buns consumption. Some state that it might be", image:"https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg", category_id: 3)

--- a/features/Visitor_can_register_for_an_account.feature
+++ b/features/Visitor_can_register_for_an_account.feature
@@ -1,5 +1,4 @@
 Feature: Visitor can register for an account
-
    As a Visitor,
    In order to access unique features on the news app,
    I would like to be able to register for an account on the site.

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -25,8 +25,8 @@ Then("I should not see {string} for {string}") do |expected_content, title|
 end
 
 Then("I should see {string} in {string}") do |expected_content, name|
-	@category = Category.find_by_name(name)
-	within("#category_#{@category.id}") do
+	category = Category.find_by_name(name)
+	within("#category_#{category.id}") do
 		expect(page).to have_content expected_content
 	end
 end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -23,3 +23,10 @@ Then("I should not see {string} for {string}") do |expected_content, title|
 		expect(page).not_to have_content expected_content
 	end
 end
+
+Then("I should see {string} in {string}") do |expected_content, name|
+	@category = Category.find_by_name(name)
+	within("#category_#{@category.id}") do
+		expect(page).to have_content expected_content
+	end
+end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -1,6 +1,6 @@
 Given("the following articles exist") do |table|
   table.hashes.each do |article|
-    category = Category.find_by(name: article[:category])
+    category = Category.find_or_create_by(name: article[:category])
     article.except!('category_id')
     create(:article, article.merge(category: category))
   end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -1,6 +1,14 @@
 Given("the following articles exist") do |table|
-	table.hashes.each do |article|
-		create(:article, article)
+  table.hashes.each do |article|
+    category = Category.find_by(name: article[:category])
+    article.except!('category_id')
+    create(:article, article.merge(category: category))
+  end
+end
+
+Given("the following categories exist") do |table|
+	table.hashes.each do |category|
+		create(:category, category)
 	end
 end
 

--- a/features/visitor_can_read_a_specific_article.feature
+++ b/features/visitor_can_read_a_specific_article.feature
@@ -4,10 +4,14 @@ Feature: Visitor can read a specific article
 	I would like to be able to click on an article and have it displayed on a separate page
 
 	Background:
-		Given the following articles exist
-			| title                                          | content                                                      | image																																		|
-			| The Hub News is the site of the moment         | Great articles! This site's popularity is raising so quick!  |	https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg		|
-			| Spring hasn't arrived in Sweden yet            | Ice can be still spotted on the street, watch out!           | https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg   |
+		Given the following categories exist
+		| name 		|
+		| sports	|
+		| tech   	|
+		And the following articles exist
+		| title                                          | content                                                      | image																																		| category |
+		| The Hub News is the site of the moment         | Great articles! This site's popularity is raising so quick!  |	https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg		|		tech	 |
+		| Spring hasn't arrived in Sweden yet            | Ice can be still spotted on the street, watch out!           | https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg   |	sports	 |
 
 	Scenario: Visitor can read a specific article
 		Given I visit the "landing" page

--- a/features/visitor_can_read_a_specific_article.feature
+++ b/features/visitor_can_read_a_specific_article.feature
@@ -4,11 +4,7 @@ Feature: Visitor can read a specific article
 	I would like to be able to click on an article and have it displayed on a separate page
 
 	Background:
-		Given the following categories exist
-		| name 		|
-		| sports	|
-		| tech   	|
-		And the following articles exist
+		Given the following articles exist
 		| title                                          | content                                                      | image																																		| category |
 		| The Hub News is the site of the moment         | Great articles! This site's popularity is raising so quick!  |	https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg		|		tech	 |
 		| Spring hasn't arrived in Sweden yet            | Ice can be still spotted on the street, watch out!           | https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg   |	sports	 |

--- a/features/visitor_can_see_categorized_articles.feature
+++ b/features/visitor_can_see_categorized_articles.feature
@@ -26,3 +26,4 @@ Feature: Visitor can see categorized articles
 		And I should see "Entertainment"
 		And I should see "Politics"
 		And I should see "The Hub News is the site of the moment" in "sports"
+		And I should see "Spring hasn't arrived in Sweden yet" in "tech"

--- a/features/visitor_can_see_categorized_articles.feature
+++ b/features/visitor_can_see_categorized_articles.feature
@@ -1,23 +1,21 @@
 Feature: Visitor can see categorized articles
-
 	As a Visitor
 	In order to find relevant articles
 	I would like for the articles to be categorized.
 
 	Background:
-	Given the following categories exist
-		| 	   name 			|
-		| 	sports				|
-		|   tech   				|
-		| 	local					|
-		| entertainment 	|
-		|	global 					|
-		|	politics 				|
-
-	And the following articles exist
-		| title                                          | content                                                      | image																																		| category |
-		| The Hub News is the site of the moment         | Great articles! This site's popularity is raising so quick!  |	https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg		| sports	 |
-		| Spring hasn't arrived in Sweden yet            | Ice can be still spotted on the street, watch out!           | https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg   | tech 		 |
+		Given the following categories exist
+			| name          |
+			| sports        |
+			| tech          |
+			| local         |
+			| entertainment |
+			| global        |
+			| politics      |
+		And the following articles exist
+			| title                                  | content                                                     | image                                                                 | category |
+			| The Hub News is the site of the moment | Great articles! This site's popularity is raising so quick! | https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg | sports   |
+			| Spring hasn't arrived in Sweden yet    | Ice can be still spotted on the street, watch out!          | https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg | tech     |
 
 	Scenario: Visitor can see category links
 		Given I visit the "landing" page
@@ -27,4 +25,4 @@ Feature: Visitor can see categorized articles
 		And I should see "Tech"
 		And I should see "Entertainment"
 		And I should see "Politics"
-
+		And I should see "The Hub News is the site of the moment" in "sports"

--- a/features/visitor_can_see_categorized_articles.feature
+++ b/features/visitor_can_see_categorized_articles.feature
@@ -1,0 +1,30 @@
+Feature: Visitor can see categorized articles
+
+	As a Visitor
+	In order to find relevant articles
+	I would like for the articles to be categorized.
+
+	Background:
+	Given the following categories exist
+		| 	   name 			|
+		| 	sports				|
+		|   tech   				|
+		| 	local					|
+		| entertainment 	|
+		|	global 					|
+		|	politics 				|
+
+	And the following articles exist
+		| title                                          | content                                                      | image																																		| category |
+		| The Hub News is the site of the moment         | Great articles! This site's popularity is raising so quick!  |	https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg		| sports	 |
+		| Spring hasn't arrived in Sweden yet            | Ice can be still spotted on the street, watch out!           | https://cdn.pixabay.com/photo/2016/11/29/04/19/beach-1867285__340.jpg   | tech 		 |
+
+	Scenario: Visitor can see category links
+		Given I visit the "landing" page
+		Then I should see "Local"
+		And I should see "Sports"
+		And I should see "Global"
+		And I should see "Tech"
+		And I should see "Entertainment"
+		And I should see "Politics"
+

--- a/features/visitor_can_view_articles_list.feature
+++ b/features/visitor_can_view_articles_list.feature
@@ -4,12 +4,7 @@ Feature: Visitor can view all listed articles
     I would like to be able to see the articles listed on a page
 
     Background:
-			Given the following categories exist
-			| name 		|
-			| sports	|
-			| tech   	|
-			| local 	|
-			And the following articles exist
+			Given the following articles exist
 			| title                                          | content                                                                                                                                                                                     | category |
 			| The Hub News is the site of the moment         | Great articles! This site's popularity is raising so quick!                                                                                                                                 |	tech		|
 			| Spring hasn't arrived in Sweden yet            | Ice can be still spotted on the street, watch out!                                                                                                                                          |	sports	|

--- a/features/visitor_can_view_articles_list.feature
+++ b/features/visitor_can_view_articles_list.feature
@@ -3,16 +3,21 @@ Feature: Visitor can view all listed articles
     In order to choose an article to read
     I would like to be able to see the articles listed on a page
 
-    Background: 
-        Given the following articles exist
-        | title                                          | content                                                                                                                                                                                     |
-        | The Hub News is the site of the moment         | Great articles! This site's popularity is raising so quick!                                                                                                                                 |
-        | Spring hasn't arrived in Sweden yet            | Ice can be still spotted on the street, watch out!                                                                                                                                          |
-        | Eating cinnamon buns increases life expectancy | Researchers are running clinical studies to see the benefits of cinnamon buns consumption. Some state that it might be correlated with an increase in life expectancy, is that really true? |
-    
+    Background:
+			Given the following categories exist
+			| name 		|
+			| sports	|
+			| tech   	|
+			| local 	|
+			And the following articles exist
+			| title                                          | content                                                                                                                                                                                     | category |
+			| The Hub News is the site of the moment         | Great articles! This site's popularity is raising so quick!                                                                                                                                 |	tech		|
+			| Spring hasn't arrived in Sweden yet            | Ice can be still spotted on the street, watch out!                                                                                                                                          |	sports	|
+			| Eating cinnamon buns increases life expectancy | Researchers are running clinical studies to see the benefits of cinnamon buns consumption. Some state that it might be correlated with an increase in life expectancy, is that really true? |	local		|
+
     Scenario: View list of articles on the landing page
-        Given I visit the "landing" page
-        Then I should see "Great articles! This site's popularity is raising so quick!" for "The Hub News is the site of the moment"
-        And I should see "Researchers are running clinical studies to see the benefits of cinnamon buns consumption. Some..." for "Eating cinnamon buns increases life expectancy"
-        But I should not see "state that it might be correlated with an increase in life expectancy, is that really true?" for "Eating cinnamon buns increases life expectancy"
-        And I should not see "Great articles! This site's popularity is raising so quick!" for "Spring hasn't arrived in Sweden yet"
+			Given I visit the "landing" page
+			Then I should see "Great articles! This site's popularity is raising so quick!" for "The Hub News is the site of the moment"
+			And I should see "Researchers are running clinical studies to see the benefits of cinnamon buns consumption. Some..." for "Eating cinnamon buns increases life expectancy"
+			But I should not see "state that it might be correlated with an increase in life expectancy, is that really true?" for "Eating cinnamon buns increases life expectancy"
+			And I should not see "Great articles! This site's popularity is raising so quick!" for "Spring hasn't arrived in Sweden yet"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :article do
     title { "MyString" }
-    content { "It is a beautiful day" }
+		content { "It is a beautiful day" }
+		category
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    name { "MyString" }
+  end
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :category do
-    name { "MyString" }
+    name { "sports" }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe Article, type: :model do
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of :title }
-    it { is_expected.to validate_presence_of :content } 
+    it { is_expected.to validate_presence_of :content }
     it { is_expected.to validate_length_of(:title).is_at_least(5) }
-    it { is_expected.to validate_length_of(:content).is_at_least(10) } 
+		it { is_expected.to validate_length_of(:content).is_at_least(10) }
+		it { should belong_to(:category) }
   end
 
   describe 'Factory' do
     it 'should have valid Factory' do
-      expect(create(:article)).to be_valid 
+      expect(create(:article)).to be_valid
     end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :content }
     it { is_expected.to validate_length_of(:title).is_at_least(5) }
 		it { is_expected.to validate_length_of(:content).is_at_least(10) }
+	end
+
+	describe 'Associations' do
 		it { should belong_to(:category) }
-  end
+	end
 
   describe 'Factory' do
     it 'should have valid Factory' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Category, type: :model do
     it { is_expected.to validate_uniqueness_of :name }
 		it { should_not allow_value("weather").for(:name) }
 		it { should allow_value("sports").for(:name) }
+		it { should have_many(:articles) }
 	end
 
   describe 'Factory' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+	describe 'DB table' do
+    it { is_expected.to have_db_column :name }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_uniqueness_of :name }
+		it { should_not allow_value("weather").for(:name) }
+		it { should allow_value("sports").for(:name) }
+	end
+
+  describe 'Factory' do
+    it 'should have valid Factory' do
+      expect(create(:category)).to be_valid
+    end
+  end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe Category, type: :model do
     it { is_expected.to validate_uniqueness_of :name }
 		it { should_not allow_value("weather").for(:name) }
 		it { should allow_value("sports").for(:name) }
+	end
+
+	describe 'Associations' do
 		it { should have_many(:articles) }
 	end
 


### PR DESCRIPTION
#### PT Story: [PivotalTracker](https://www.pivotaltracker.com/story/show/164564555)
#### Description
As a Visitor
In order to find relevant articles
I would like for the articles to be categorized

Changes proposed in this pull request:

* Add category to article
* Sort articles by category in index page

#### What I have learned working on this feature:
Association and iteration between models

#### Screenshots:
![image](https://user-images.githubusercontent.com/45640859/54394266-b49cb980-46ac-11e9-8a07-8e982c8f0cc4.png)
